### PR TITLE
fix: adding xhr2 package to fix ReferenceError with XMLHttpRequest

### DIFF
--- a/src/Request.res
+++ b/src/Request.res
@@ -21,7 +21,7 @@ type progressEvent = {
 
 module XMLHttpRequest = {
   type t<'input, 'responseType>
-  @new external make: unit => t<'input, 'responseType> = "XMLHttpRequest"
+  @new @module("xhr2") external make: unit => t<'input, 'responseType> = "XMLHttpRequest"
   @send
   external \"open": (t<'input, 'responseType>, method, string, @as(json`true`) _) => unit = "open"
   @set


### PR DESCRIPTION
XMLHttpRequest is added by default in browsers environment, but out of this environment, a import to xhr2 package is needed